### PR TITLE
feat: implement main logic for processing MARINATED variables

### DIFF
--- a/cmd/marinatemd/root.go
+++ b/cmd/marinatemd/root.go
@@ -3,8 +3,12 @@ package marinatemd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/c4a8-azure/marinatemd/internal/config"
+	"github.com/c4a8-azure/marinatemd/internal/hclparse"
+	"github.com/c4a8-azure/marinatemd/internal/schema"
+	"github.com/c4a8-azure/marinatemd/internal/yamlio"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -34,23 +38,107 @@ Example:
 			root = args[0]
 		}
 
+		// Convert to absolute path
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			return fmt.Errorf("failed to resolve module path: %w", err)
+		}
+
 		// Load configuration
 		cfg, err := config.Load()
 		if err != nil {
 			return fmt.Errorf("failed to load configuration: %w", err)
 		}
 
-		// TODO: Implement main logic here
-		// - Parse HCL variables from root
-		// - Generate/update YAML schemas
-		// - Generate markdown and inject into docs
-
-		fmt.Printf("Processing module at: %s\n", root)
+		// Print configuration info
+		fmt.Printf("Processing module at: %s\n", absRoot)
 		if viper.ConfigFileUsed() != "" {
 			fmt.Printf("Using config: %s\n", viper.ConfigFileUsed())
 		}
-		fmt.Printf("Docs path: %s\n", cfg.DocsPath)
-		fmt.Printf("README path: %s\n", cfg.ReadmePath)
+
+		// Resolve docs path relative to module root
+		docsPath := filepath.Join(absRoot, cfg.DocsPath)
+		fmt.Printf("Documentation path: %s\n", docsPath)
+
+		// Step 1: Parse HCL variables from the module
+		fmt.Println("\nParsing Terraform variables...")
+		parser := hclparse.NewParser()
+		if parseErr := parser.ParseVariables(absRoot); parseErr != nil {
+			return fmt.Errorf("failed to parse variables: %w", parseErr)
+		}
+
+		// Step 2: Extract variables marked with MARINATED
+		marinatedVars, extractErr := parser.ExtractMarinatedVars()
+		if extractErr != nil {
+			return fmt.Errorf("failed to extract marinated variables: %w", extractErr)
+		}
+
+		if len(marinatedVars) == 0 {
+			fmt.Println("WARNING: No MARINATED variables found in module")
+			fmt.Println("   Add <!-- MARINATED: variable_name --> to variable descriptions to enable documentation")
+			return nil
+		}
+
+		fmt.Printf("Found %d MARINATED variable(s)\n", len(marinatedVars))
+
+		// Step 3: Create docs/variables/ directory structure
+		variablesDir := filepath.Join(docsPath, "variables")
+		fmt.Printf("\nCreating directory structure: %s\n", variablesDir)
+		if mkdirErr := os.MkdirAll(variablesDir, 0750); mkdirErr != nil {
+			return fmt.Errorf("failed to create variables directory: %w", mkdirErr)
+		}
+
+		// Step 4: Process each MARINATED variable
+		builder := schema.NewBuilder()
+		reader := yamlio.NewReader(docsPath)
+		writer := yamlio.NewWriter(docsPath)
+
+		fmt.Println("\nProcessing variables...")
+		for _, variable := range marinatedVars {
+			fmt.Printf("\n  Processing '%s' (ID: %s)...\n", variable.Name, variable.MarinatedID)
+
+			// Build schema from HCL variable
+			newSchema, buildErr := builder.BuildFromVariable(variable)
+			if buildErr != nil {
+				return fmt.Errorf("failed to build schema for variable %s: %w", variable.Name, buildErr)
+			}
+
+			// Check if YAML schema already exists
+			existingSchema, readErr := reader.ReadSchema(variable.MarinatedID)
+			if readErr != nil {
+				return fmt.Errorf("failed to read existing schema for %s: %w", variable.MarinatedID, readErr)
+			}
+
+			var finalSchema *schema.Schema
+			if existingSchema != nil {
+				// Merge new schema with existing to preserve user descriptions
+				fmt.Printf("    Merging with existing schema...\n")
+				var mergeErr error
+				finalSchema, mergeErr = builder.MergeWithExisting(newSchema, existingSchema)
+				if mergeErr != nil {
+					return fmt.Errorf("failed to merge schemas for %s: %w", variable.MarinatedID, mergeErr)
+				}
+			} else {
+				// No existing schema, use new one
+				fmt.Printf("    Creating new schema...\n")
+				finalSchema = newSchema
+			}
+
+			// Write the schema to YAML file
+			yamlPath := filepath.Join(variablesDir, variable.MarinatedID+".yaml")
+			if writeErr := writer.WriteSchema(finalSchema); writeErr != nil {
+				return fmt.Errorf("failed to write schema for %s: %w", variable.MarinatedID, writeErr)
+			}
+
+			fmt.Printf("    Written to %s\n", yamlPath)
+		}
+
+		// Success summary
+		fmt.Printf("\nSuccessfully processed %d variable(s)\n", len(marinatedVars))
+		fmt.Printf("   YAML schemas written to: %s\n", variablesDir)
+		fmt.Println("\nNext steps:")
+		fmt.Println("   1. Review and edit the generated YAML files to add descriptions")
+		fmt.Println("   2. Run marinatemd again to regenerate markdown (when implemented)")
 
 		return nil
 	},


### PR DESCRIPTION
This pull request implements the main logic for the `marinatemd` CLI tool, enabling it to parse Terraform module variables, extract those marked for documentation, and generate or update YAML schema files for each variable. It introduces structured processing, error handling, and clear output messages to guide the user through the documentation workflow.

Core functionality for MARINATED variable processing:

* Converts the provided module path to an absolute path and resolves documentation paths relative to it, ensuring consistent file operations.
* Parses Terraform variables using a new HCL parser, extracts variables marked as MARINATED, and warns if none are found, instructing users how to enable documentation.
* For each MARINATED variable, builds a schema, merges with any existing YAML schema to preserve user edits, and writes the resulting schema to a YAML file in a structured directory.

Improvements to user experience and output:

* Prints detailed progress and summary messages, including next steps for reviewing and editing generated YAML files.

Dependency and import updates:

* Adds imports for new internal packages (`hclparse`, `schema`, `yamlio`) to support parsing, schema building, and YAML I/O operations.