### PR TITLE
fix: update binary name from marinatemd to marinate

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,7 @@ before:
 builds:
   - id: marinatemd
     main: ./main.go
-    binary: marinatemd
+    binary: marinate
 
     # Environments to build for
     env:
@@ -45,9 +45,9 @@ builds:
 
     ldflags:
       - -s -w
-      - -X github.com/glueckkanja/marinatemd/cmd/marinatemd.version={{.Version}}
-      - -X github.com/glueckkanja/marinatemd/cmd/marinatemd.commit={{.Commit}}
-      - -X github.com/glueckkanja/marinatemd/cmd/marinatemd.date={{.Date}}
+      - -X github.com/glueckkanja/marinatemd/cmd/marinatemd.Version={{.Version}}
+      - -X github.com/glueckkanja/marinatemd/cmd/marinatemd.Commit={{.Commit}}
+      - -X github.com/glueckkanja/marinatemd/cmd/marinatemd.BuildDate={{.Date}}
 
 archives:
   - id: marinatemd-archive

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-BINARY_NAME := marinatemd
+BINARY_NAME := marinate
 VERSION ?= dev
 # Fallback must match the default in cmd/marinatemd/version.go
 COMMIT_FALLBACK := none

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If you're using terraform-docs for basic variable documentation, run it now to g
 Run the inject command to read your YAML schemas and inject hierarchical markdown:
 
 ```bash
-marinatemd inject
+marinate inject
 ```
 
 This generates markdown like:
@@ -165,8 +165,8 @@ Parses `variables.tf` files for variables marked with `<!-- MARINATED: name -->`
 **Basic usage:**
 
 ```bash
-marinatemd export .
-marinatemd export /path/to/terraform/module
+marinate export .
+marinate export /path/to/terraform/module
 ```
 
 **What it does:**
@@ -195,16 +195,16 @@ Reads YAML schemas and renders them as hierarchical markdown, injecting the outp
 
 ```bash
 # Default: inject from ./docs/variables/*.yaml into ./README.md
-marinatemd inject
+marinate inject
 
 # Custom schema directory
-marinatemd inject /path/to/yaml/schemas
+marinate inject /path/to/yaml/schemas
 
 # Inject into Terraform variable files instead
-marinatemd inject --inject-type terraform --terraform-module ./terraform
+marinate inject --inject-type terraform --terraform-module ./terraform
 
 # Inject into both README and Terraform files
-marinatemd inject --inject-type both --terraform-module ./terraform
+marinate inject --inject-type both --terraform-module ./terraform
 ```
 
 **Arguments:**
@@ -231,19 +231,19 @@ marinatemd inject --inject-type both --terraform-module ./terraform
 
 ```bash
 # Default paths
-marinatemd inject
+marinate inject
 
 # Custom markdown target
-marinatemd inject --markdown-file docs/VARIABLES.md
+marinate inject --markdown-file docs/VARIABLES.md
 
 # Update Terraform files with rendered docs
-marinatemd inject --inject-type terraform --terraform-module .
+marinate inject --inject-type terraform --terraform-module .
 
 # Update both README and Terraform files
-marinatemd inject --inject-type both --terraform-module . --markdown-file README.md
+marinate inject --inject-type both --terraform-module . --markdown-file README.md
 
 # Custom schema location
-marinatemd inject /custom/schemas --markdown-file docs/API.md
+marinate inject /custom/schemas --markdown-file docs/API.md
 ```
 
 **Path resolution:**
@@ -258,13 +258,13 @@ Takes a markdown file with multiple MARINATED variable sections and splits it in
 
 ```bash
 # Default: split docs/README.md into docs/variables/*.md
-marinatemd split .
+marinate split .
 
 # Custom paths
-marinatemd split --input docs/README.md --output docs/split .
+marinate split --input docs/README.md --output docs/split .
 
 # Add header/footer templates
-marinatemd split --header _header.md --footer _footer.md .
+marinate split --header _header.md --footer _footer.md .
 ```
 
 **Flags:**
@@ -292,10 +292,10 @@ Useful when you want per-variable documentation files instead of a monolithic RE
 terraform-docs markdown table . > docs/README.md
 
 # Inject MARINATED documentation
-marinatemd inject --markdown-file docs/README.md
+marinate inject --markdown-file docs/README.md
 
 # Split into individual files with custom header/footer
-marinatemd split --header templates/header.md --footer templates/footer.md
+marinate split --header templates/header.md --footer templates/footer.md
 ```
 
 ## Configuration


### PR DESCRIPTION
This pull request renames the CLI tool from `marinatemd` to `marinate`, and updates related documentation to match the new naming. It also updates linker flags to use capitalized variable names for versioning information.

**Tool and Binary Renaming:**

* Changed the binary name from `marinatemd` to `marinate` in `.goreleaser.yaml` and `Makefile`. [[1]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L16-R16) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L2-R2)

**Documentation Updates:**

* Updated all usage examples and command references in `README.md` from `marinatemd` to `marinate` to reflect the new tool name. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R134) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L168-R169) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L198-R207) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L234-R246) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L261-R267) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L295-R298)

**Build Configuration:**

* Updated linker flags in `.goreleaser.yaml` to use capitalized variable names (`Version`, `Commit`, `BuildDate`) for version, commit, and build date metadata.