### PR TITLE
fix: update markdown file handling to use configuration for defaults

### DIFF
--- a/cmd/marinatemd/split.go
+++ b/cmd/marinatemd/split.go
@@ -48,7 +48,7 @@ func init() {
 		&splitInputFile,
 		"input",
 		"",
-		"input markdown file to split (defaults to docs/README.md)",
+		"input markdown file to split (defaults to docs_file from configuration)",
 	)
 
 	splitCmd.Flags().StringVar(
@@ -101,10 +101,21 @@ func resolveInputPath(moduleRoot string, cfg *config.Config) string {
 		exportPath := paths.ResolveExportPath(moduleRoot, cfg)
 		return filepath.Join(exportPath, cfg.Split.InputPath)
 	default:
-		// Use docs_file as default (relative to export_path)
-		exportPath := paths.ResolveExportPath(moduleRoot, cfg)
-		return filepath.Join(exportPath, cfg.DocsFile)
+		return resolveDefaultDocsFile(moduleRoot, cfg)
 	}
+}
+
+func resolveDefaultDocsFile(moduleRoot string, cfg *config.Config) string {
+	docsFile := "README.md"
+	if cfg != nil && cfg.DocsFile != "" {
+		docsFile = cfg.DocsFile
+	}
+
+	if filepath.IsAbs(docsFile) {
+		return docsFile
+	}
+
+	return filepath.Join(moduleRoot, docsFile)
 }
 
 func resolveOutputDir(moduleRoot string, cfg *config.Config) string {


### PR DESCRIPTION
This pull request updates how the default markdown file is determined for both the inject and split commands. Instead of always defaulting to `README.md` in the current directory, the tools now use the `docs_file` setting from the configuration (relative to the module root) when available. The changes improve consistency and configurability for users.

**Markdown file resolution improvements:**

* The `inject` command now uses the `docs_file` from configuration (relative to the module root) as its default markdown file, instead of always defaulting to `<current-dir>/README.md`. This is reflected in the CLI help text and the logic for resolving paths. [[1]](diffhunk://#diff-9961e8782c94eaaf3711c5069ebc3e6c2a142fef3e4d5bf2c6797c916b098472L46-R46) [[2]](diffhunk://#diff-9961e8782c94eaaf3711c5069ebc3e6c2a142fef3e4d5bf2c6797c916b098472L298-R298) [[3]](diffhunk://#diff-9961e8782c94eaaf3711c5069ebc3e6c2a142fef3e4d5bf2c6797c916b098472L351-R351) [[4]](diffhunk://#diff-9961e8782c94eaaf3711c5069ebc3e6c2a142fef3e4d5bf2c6797c916b098472R366-R391)
* The `split` command's help text and logic now also reference `docs_file` from configuration as the default input markdown file, and a new helper function (`resolveDefaultDocsFile`) encapsulates this behavior. [[1]](diffhunk://#diff-100d902ec7cf9761f2d1b4ce177106a86efcb3d71c1806fe3f465e8a75e90af6L51-R51) [[2]](diffhunk://#diff-100d902ec7cf9761f2d1b4ce177106a86efcb3d71c1806fe3f465e8a75e90af6L104-R118)

**Code refactoring for path resolution:**

* The `resolveInjectPaths` and `resolveMarkdownPath` functions in `inject.go` were refactored to accept `moduleRoot` and configuration as parameters, enabling the new default behavior and making the code more modular. [[1]](diffhunk://#diff-9961e8782c94eaaf3711c5069ebc3e6c2a142fef3e4d5bf2c6797c916b098472L108-R108) [[2]](diffhunk://#diff-9961e8782c94eaaf3711c5069ebc3e6c2a142fef3e4d5bf2c6797c916b098472L286-R286) [[3]](diffhunk://#diff-9961e8782c94eaaf3711c5069ebc3e6c2a142fef3e4d5bf2c6797c916b098472L298-R298) [[4]](diffhunk://#diff-9961e8782c94eaaf3711c5069ebc3e6c2a142fef3e4d5bf2c6797c916b098472L351-R351) [[5]](diffhunk://#diff-9961e8782c94eaaf3711c5069ebc3e6c2a142fef3e4d5bf2c6797c916b098472R366-R391)