### PR TITLE
Add variable config name overrides

### DIFF
--- a/examples/docs/variables/app_config.yaml
+++ b/examples/docs/variables/app_config.yaml
@@ -1,5 +1,7 @@
 variable: app_config
 version: "1"
+config:
+    name: important_resources
 schema:
     cache:
         _marinate:

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -20,7 +20,13 @@ var (
 type Schema struct {
 	Variable    string           `yaml:"variable"`
 	Version     string           `yaml:"version"`
+	Config      *VariableConfig  `yaml:"config,omitempty"`
 	SchemaNodes map[string]*Node `yaml:"schema"`
+}
+
+// VariableConfig represents user-controlled settings for a variable schema.
+type VariableConfig struct {
+	Name string `yaml:"name,omitempty"`
 }
 
 // Node represents a node in the schema tree.
@@ -649,6 +655,7 @@ func (b *Builder) MergeWithExisting(newSchema, existing *Schema) (*Schema, error
 	merged := &Schema{
 		Variable:    newSchema.Variable,
 		Version:     newSchema.Version,
+		Config:      b.mergeVariableConfig(newSchema.Config, existing.Config),
 		SchemaNodes: make(map[string]*Node),
 	}
 
@@ -877,4 +884,26 @@ func splitByComma(s string) []string {
 	}
 
 	return result
+}
+
+func (b *Builder) mergeVariableConfig(newCfg, existingCfg *VariableConfig) *VariableConfig {
+	if newCfg == nil && existingCfg == nil {
+		return nil
+	}
+
+	merged := &VariableConfig{}
+
+	if existingCfg != nil && existingCfg.Name != "" {
+		merged.Name = existingCfg.Name
+	}
+
+	if newCfg != nil && newCfg.Name != "" {
+		merged.Name = newCfg.Name
+	}
+
+	if merged.Name == "" {
+		return nil
+	}
+
+	return merged
 }


### PR DESCRIPTION
This pull request introduces support for custom output filenames when splitting Markdown documentation for variables, based on a new `config.name` field in schema YAML files. It also adds the ability to preserve or override these custom names during schema merges, and ensures these behaviors are robustly tested. The changes span the CLI, core logic, schema handling, and tests.

**Support for custom output filenames and schema config:**

* Added a `config.name` field to variable schema YAML files (see `examples/docs/variables/app_config.yaml`) to allow specifying a custom output filename for each variable. [[1]](diffhunk://#diff-f0037aad7a2ab6c8b260e24a7e2ddacae60ba7080d3e2328a5367d3704656844R3-R4) [[2]](diffhunk://#diff-3c8b74cbf2bd78f25c9f79b06136d5f2553f0877bde14446596a3a538db860dfR23-R31)
* Updated the Markdown splitter (`internal/markdown/splitter.go`) to support name overrides via a new `SetNameOverride` method and to use the override when generating output filenames. [[1]](diffhunk://#diff-41d81b70a78823e416a3f1a7cc4fa6be4a34eaa216865edb112149f8a16762c3R21-R28) [[2]](diffhunk://#diff-41d81b70a78823e416a3f1a7cc4fa6be4a34eaa216865edb112149f8a16762c3R64-R84) [[3]](diffhunk://#diff-41d81b70a78823e416a3f1a7cc4fa6be4a34eaa216865edb112149f8a16762c3L257-R281)
* The CLI `split` command (`cmd/marinatemd/split.go`) now reads schema files for variables and applies any configured name overrides before splitting documentation. [[1]](diffhunk://#diff-100d902ec7cf9761f2d1b4ce177106a86efcb3d71c1806fe3f465e8a75e90af6R4-R15) [[2]](diffhunk://#diff-100d902ec7cf9761f2d1b4ce177106a86efcb3d71c1806fe3f465e8a75e90af6R96-R99) [[3]](diffhunk://#diff-100d902ec7cf9761f2d1b4ce177106a86efcb3d71c1806fe3f465e8a75e90af6R220-R248) [[4]](diffhunk://#diff-100d902ec7cf9761f2d1b4ce177106a86efcb3d71c1806fe3f465e8a75e90af6L164-L173)

**Schema merging and config preservation:**

* Enhanced schema merging logic to preserve or override the `config.name` field as appropriate, ensuring that new values take precedence and existing ones are preserved if new is empty. [[1]](diffhunk://#diff-3c8b74cbf2bd78f25c9f79b06136d5f2553f0877bde14446596a3a538db860dfR658) [[2]](diffhunk://#diff-3c8b74cbf2bd78f25c9f79b06136d5f2553f0877bde14446596a3a538db860dfR888-R909)

**Testing and reliability:**

* Added comprehensive tests for the new name override logic in both the splitter and schema merging, ensuring correct file creation and config precedence. [[1]](diffhunk://#diff-db661e267fc455b05df0c488a7ac57ea4312a3567a3c1a1d983dfbe4d23e18fbR443-R494) [[2]](diffhunk://#diff-d0e1cc82c3f1250cc042aa888f586ac0bcc52d1f5e2596123fc724b3c75f406eR246-R248) [[3]](diffhunk://#diff-d0e1cc82c3f1250cc042aa888f586ac0bcc52d1f5e2596123fc724b3c75f406eR276-R278) [[4]](diffhunk://#diff-d0e1cc82c3f1250cc042aa888f586ac0bcc52d1f5e2596123fc724b3c75f406eR517-R564) [[5]](diffhunk://#diff-d0e1cc82c3f1250cc042aa888f586ac0bcc52d1f5e2596123fc724b3c75f406eR26)

**YAML writing improvements:**

* Updated YAML writer to use a consistent indent size and to write files using a YAML encoder for improved formatting. [[1]](diffhunk://#diff-d2d06841e55914ade6da5746d974cdece3373441d88b0750b26fdcd4e0cb936aR12-R13) [[2]](diffhunk://#diff-d2d06841e55914ade6da5746d974cdece3373441d88b0750b26fdcd4e0cb936aL92-R105)