### PR TITLE
fix: export nested maps fully and preserve reserved-name object fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Build
+go build ./...
+
+# Run tests (all)
+go test -v -race ./...
+
+# Run a single test
+go test -v -run TestName ./internal/package/...
+
+# Lint
+golangci-lint run --timeout=5m
+
+# Format
+gofmt -s -w .
+
+# Vet
+go vet ./...
+```
+
+## Architecture
+
+MarinateMD is a Go CLI tool that improves documentation for complex Terraform/OpenTofu variables. The core pipeline is:
+
+**Parse HCL → Build Schema → Merge YAML → Render Markdown → Inject into docs**
+
+### Package Responsibilities
+
+- **`cmd/marinate/main.go`** - Entrypoint, delegates to `cmd/marinatemd`
+- **`cmd/marinatemd/`** - Cobra CLI commands (`root.go`, `export.go`, plus inject/split commands). Uses Viper for config/flags.
+- **`internal/config/`** - `Config` struct mapped from `.marinated.yml` via Viper. `SetDefaults()` called at init, `Load()` called per-command.
+- **`internal/hclparse/`** - Parses `variables.tf` files using `hashicorp/hcl/v2`. `Parser.ParseVariables()` + `ExtractMarinatedVars()` finds variables with `description = "<!-- MARINATED: name -->"`. `injector.go` handles injecting rendered markdown back into HCL files.
+- **`internal/schema/`** - `Builder` converts parsed HCL variable types into an internal `Schema` struct. `MergeWithExisting()` preserves user-written descriptions when schema changes.
+- **`internal/yamlio/`** - `Reader`/`Writer` for YAML schema files under `docs/variables/*.yaml`. The YAML format uses `_marinate` keys for metadata within the nested attribute structure.
+- **`internal/markdown/`** - `renderer.go` turns a Schema into hierarchical markdown using Go templates. `injector.go` injects rendered output between `<!-- MARINATED: name -->` / `<!-- /MARINATED: name -->` markers. `template.go` defines `TemplateConfig` controlling output format.
+- **`internal/paths/`** - Path resolution utilities shared across commands.
+- **`internal/logger/`** - Thin wrapper around `charmbracelet/log`.
+
+### Key Conventions
+
+- **Marinated marker**: Variables opt-in via `description = "<!-- MARINATED: variable_name -->"` in HCL. The name after `MARINATED:` is the schema ID and maps to `docs/variables/<id>.yaml`.
+- **YAML schema structure**: Each field has a `_marinate` subkey with `description`, `type`, `required`, `default`, `example`. The nesting mirrors the HCL object structure. User descriptions under `_marinate` are preserved across schema updates.
+- **Config priority**: CLI flags > `.marinated.yml` > built-in defaults. Config is searched in `.`, `.config/`, and `~/.marinated.d/`. Env vars prefixed `MARINATED_` are also supported.
+- **Deterministic output**: Generated YAML and markdown must be stable across runs (consistent ordering) to avoid noisy diffs.
+- **Test packages**: Tests use a separate `_test` package (enforced by `testpackage` linter).
+- **No global loggers**: `sloglint` enforces no global logger usage; pass logger via `internal/logger` package.
+- **Line length**: 120 chars max (enforced by `golines`).

--- a/internal/hclparse/injector.go
+++ b/internal/hclparse/injector.go
@@ -342,10 +342,10 @@ func convertToMultilineDescription(line, marinatedID, markdownContent string) st
 	var result strings.Builder
 	result.WriteString(indent)
 	result.WriteString("description = <<-EOT\n")
-	result.WriteString(fmt.Sprintf("<!-- MARINATED: %s -->\n\n", marinatedID))
+	fmt.Fprintf(&result, "<!-- MARINATED: %s -->\n\n", marinatedID)
 	result.WriteString(markdownContent)
 	result.WriteString("\n\n")
-	result.WriteString(fmt.Sprintf("<!-- /MARINATED: %s -->\n", marinatedID))
+	fmt.Fprintf(&result, "<!-- /MARINATED: %s -->\n", marinatedID)
 	result.WriteString(indent)
 	result.WriteString("EOT")
 

--- a/internal/schema/description_field_test.go
+++ b/internal/schema/description_field_test.go
@@ -76,6 +76,98 @@ func TestBuildFromHCL_FieldNamedDescription(t *testing.T) {
 	}
 }
 
+// TestBuildFromHCL_FieldNamedType tests that an object field named "type" is not dropped.
+func TestBuildFromHCL_FieldNamedType(t *testing.T) {
+	t.Parallel()
+
+	variable := &hclparse.Variable{
+		Name: "resource_config",
+		Type: `object({
+			type    = string
+			enabled = optional(bool)
+		})`,
+		Description: "<!-- MARINATED: resource_config -->",
+		MarinatedID: "resource_config",
+	}
+
+	b := schema.NewBuilder()
+	s, err := b.BuildFromVariable(variable)
+	if err != nil {
+		t.Fatalf("BuildFromVariable() error = %v", err)
+	}
+
+	typeField, ok := s.SchemaNodes["type"]
+	if !ok {
+		t.Fatal("expected 'type' field in schema nodes")
+	}
+	if typeField.Marinate.Type != "string" {
+		t.Errorf("type field type = %v, want string", typeField.Marinate.Type)
+	}
+	if !typeField.Marinate.Required {
+		t.Error("expected type field to be required")
+	}
+}
+
+// TestYAMLMarshalUnmarshal_FieldNamedType tests roundtrip for a schema with a field named "type".
+func TestYAMLMarshalUnmarshal_FieldNamedType(t *testing.T) {
+	t.Parallel()
+
+	original := &schema.Schema{
+		Variable: "resource_config",
+		Version:  "1",
+		SchemaNodes: map[string]*schema.Node{
+			"type": {
+				Marinate: &schema.MarinateInfo{
+					Type:        "string",
+					Required:    true,
+					Description: "The resource type",
+				},
+				Attributes: map[string]*schema.Node{},
+			},
+			"enabled": {
+				Marinate: &schema.MarinateInfo{
+					Type:        "bool",
+					Required:    false,
+					Description: "Whether the resource is enabled",
+				},
+				Attributes: map[string]*schema.Node{},
+			},
+		},
+	}
+
+	tmpDir := t.TempDir()
+
+	writer := yamlio.NewWriter(tmpDir)
+	if err := writer.WriteSchema(original); err != nil {
+		t.Fatalf("WriteSchema() error = %v", err)
+	}
+
+	reader := yamlio.NewReader(tmpDir)
+	read, err := reader.ReadSchema("resource_config")
+	if err != nil {
+		t.Fatalf("ReadSchema() error = %v", err)
+	}
+
+	typeField, ok := read.SchemaNodes["type"]
+	if !ok {
+		t.Fatal("expected 'type' node after roundtrip")
+	}
+	if typeField.Marinate.Type != "string" {
+		t.Errorf("type = %v, want string", typeField.Marinate.Type)
+	}
+	if typeField.Marinate.Description != "The resource type" {
+		t.Errorf("description = %v, want 'The resource type'", typeField.Marinate.Description)
+	}
+
+	enabled, ok := read.SchemaNodes["enabled"]
+	if !ok {
+		t.Fatal("expected 'enabled' node after roundtrip")
+	}
+	if enabled.Marinate.Required {
+		t.Error("expected enabled to be optional")
+	}
+}
+
 // TestYAMLMarshalUnmarshal_FieldNamedDescription tests that we can
 // marshal and unmarshal a schema with a field named "description".
 func TestYAMLMarshalUnmarshal_FieldNamedDescription(t *testing.T) {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -61,16 +61,6 @@ func (n *Node) UnmarshalYAML(value *yaml.Node) error {
 	// Initialize attributes map
 	n.Attributes = make(map[string]*Node)
 
-	// Known fields that are part of the Node struct
-	knownFields := map[string]bool{
-		"_marinate":    true,
-		"type":         true,
-		"required":     true,
-		"element_type": true,
-		"value_type":   true,
-		"default":      true,
-	}
-
 	// Iterate through the mapping node
 	for i := 0; i < len(value.Content); i += 2 {
 		keyNode := value.Content[i]
@@ -87,13 +77,11 @@ func (n *Node) UnmarshalYAML(value *yaml.Node) error {
 			n.Marinate = &marinate
 		default:
 			// All other fields are child attributes
-			if !knownFields[fieldName] {
-				var childNode Node
-				if err := valueNode.Decode(&childNode); err != nil {
-					return fmt.Errorf("failed to decode attribute %s: %w", fieldName, err)
-				}
-				n.Attributes[fieldName] = &childNode
+			var childNode Node
+			if err := valueNode.Decode(&childNode); err != nil {
+				return fmt.Errorf("failed to decode attribute %s: %w", fieldName, err)
 			}
+			n.Attributes[fieldName] = &childNode
 		}
 	}
 
@@ -342,6 +330,23 @@ func (b *Builder) parseMapFieldType(typeExpr string, node *Node) error {
 	if strings.HasPrefix(innerType, "object(") {
 		return b.parseNestedObjectChildren(innerType, node)
 	}
+	// If map contains another map, recurse into it via a _values child node
+	if strings.HasPrefix(innerType, "map(") {
+		return b.parseNestedMapChildren(innerType, node)
+	}
+	return nil
+}
+
+// parseNestedMapChildren creates a _values child node and recursively parses the inner map type.
+func (b *Builder) parseNestedMapChildren(mapTypeExpr string, node *Node) error {
+	valuesNode := &Node{
+		Marinate:   &MarinateInfo{},
+		Attributes: make(map[string]*Node),
+	}
+	if err := b.parseMapFieldType(mapTypeExpr, valuesNode); err != nil {
+		return err
+	}
+	node.Attributes["_values"] = valuesNode
 	return nil
 }
 
@@ -619,6 +624,13 @@ func (b *Builder) parseMapType(typeExpr string, nodes map[string]*Node, contextN
 				return parseErr5
 			}
 			node.Attributes[name] = childNode
+		}
+	}
+
+	// If map contains another map, recurse into it via a _values child node
+	if strings.HasPrefix(innerType, "map(") {
+		if err := b.parseNestedMapChildren(innerType, node); err != nil {
+			return err
 		}
 	}
 

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -562,3 +562,54 @@ func TestMergeVariableConfig_PreserveExistingWhenNewEmpty(t *testing.T) {
 		t.Fatalf("expected config name to remain legacy, got %+v", merged.Config)
 	}
 }
+
+// TestBuildFromHCL_NestedMap tests that map(map(object({...}))) is fully exported.
+func TestBuildFromHCL_NestedMap(t *testing.T) {
+	t.Parallel()
+
+	variable := &hclparse.Variable{
+		Name:        "layers",
+		Type:        `map(map(object({ name = string })))`,
+		Description: "<!-- MARINATED: layers -->",
+		MarinatedID: "layers",
+	}
+
+	b := schema.NewBuilder()
+	s, err := b.BuildFromVariable(variable)
+	if err != nil {
+		t.Fatalf("BuildFromVariable() error = %v", err)
+	}
+
+	root, ok := s.SchemaNodes["_root"]
+	if !ok {
+		t.Fatal("expected '_root' node")
+	}
+	if root.Marinate.Type != "map" {
+		t.Errorf("_root type = %v, want map", root.Marinate.Type)
+	}
+	if root.Marinate.ValueType != "map" {
+		t.Errorf("_root value_type = %v, want map", root.Marinate.ValueType)
+	}
+
+	values, ok := root.Attributes["_values"]
+	if !ok {
+		t.Fatal("expected '_values' child node on _root")
+	}
+	if values.Marinate.Type != "map" {
+		t.Errorf("_values type = %v, want map", values.Marinate.Type)
+	}
+	if values.Marinate.ValueType != "object" {
+		t.Errorf("_values value_type = %v, want object", values.Marinate.ValueType)
+	}
+
+	nameField, ok := values.Attributes["name"]
+	if !ok {
+		t.Fatal("expected 'name' field in _values attributes")
+	}
+	if nameField.Marinate.Type != "string" {
+		t.Errorf("name type = %v, want string", nameField.Marinate.Type)
+	}
+	if !nameField.Marinate.Required {
+		t.Error("expected name to be required")
+	}
+}

--- a/internal/yamlio/io_test.go
+++ b/internal/yamlio/io_test.go
@@ -295,6 +295,86 @@ func TestWriter_PreserveExistingDescriptions(t *testing.T) {
 	}
 }
 
+// TestWriter_FieldNamedType tests that we can write and read a schema
+// with fields named after historically-reserved names like "type", "required", etc.
+func TestWriter_FieldNamedType(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	originalSchema := &schema.Schema{
+		Variable: "resource_config",
+		Version:  "1",
+		SchemaNodes: map[string]*schema.Node{
+			"settings": {
+				Marinate: &schema.MarinateInfo{
+					Description: "Settings block",
+					Type:        "object",
+					Required:    true,
+				},
+				Attributes: map[string]*schema.Node{
+					"type": {
+						Marinate: &schema.MarinateInfo{
+							Description: "Resource type identifier",
+							Type:        "string",
+							Required:    true,
+						},
+						Attributes: map[string]*schema.Node{},
+					},
+					"required": {
+						Marinate: &schema.MarinateInfo{
+							Description: "Whether this resource is required",
+							Type:        "bool",
+							Required:    false,
+						},
+						Attributes: map[string]*schema.Node{},
+					},
+					"default": {
+						Marinate: &schema.MarinateInfo{
+							Description: "Default value for the setting",
+							Type:        "string",
+							Required:    false,
+						},
+						Attributes: map[string]*schema.Node{},
+					},
+				},
+			},
+		},
+	}
+
+	writer := yamlio.NewWriter(tmpDir)
+	if err := writer.WriteSchema(originalSchema); err != nil {
+		t.Fatalf("WriteSchema() error = %v", err)
+	}
+
+	reader := yamlio.NewReader(tmpDir)
+	readSchema, err := reader.ReadSchema("resource_config")
+	if err != nil {
+		t.Fatalf("ReadSchema() error = %v", err)
+	}
+
+	settings := readSchema.SchemaNodes["settings"]
+	if settings == nil {
+		t.Fatal("expected 'settings' node")
+	}
+
+	for _, fieldName := range []string{"type", "required", "default"} {
+		attr, ok := settings.Attributes[fieldName]
+		if !ok {
+			t.Errorf("expected attribute %q to exist after roundtrip", fieldName)
+			continue
+		}
+		if attr.Marinate == nil {
+			t.Errorf("expected _marinate on attribute %q", fieldName)
+		}
+	}
+
+	typeAttr := settings.Attributes["type"]
+	if typeAttr != nil && typeAttr.Marinate.Description != "Resource type identifier" {
+		t.Errorf("type description = %v, want 'Resource type identifier'", typeAttr.Marinate.Description)
+	}
+}
+
 // TestWriter_FieldNamedDescription tests that we can write and read
 // a schema with a field named "description" without conflicts.
 func TestWriter_FieldNamedDescription(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes #26 — `map(map(object({...})))` types are now fully exported. The inner map structure and its object fields were previously omitted from the YAML schema. Added a `parseNestedMapChildren` helper that creates a `_values` child node and recurses, with matching branches in both `parseMapType` and `parseMapFieldType`.
- Fixes #27 — Object fields named `type`, `required`, `element_type`, `value_type`, or `default` were silently dropped during YAML read-back. These names were listed in a `knownFields` guard (a legacy artifact) alongside `_marinate`, causing them to be skipped when encountered as child attributes. Removed all legacy names from the guard so only `_marinate` receives special handling.

## Test plan

- [ ] `go test -v -run TestBuildFromHCL_NestedMap ./internal/schema/...` — verifies `_root` → `_values` → object fields for `map(map(object({...})))`
- [ ] `go test -v -run TestBuildFromHCL_FieldNamedType ./internal/schema/...` — verifies `type` field is not dropped from HCL parse
- [ ] `go test -v -run TestYAMLMarshalUnmarshal_FieldNamedType ./internal/schema/...` — write/read roundtrip with field named `type`
- [ ] `go test -v -run TestWriter_FieldNamedType ./internal/yamlio/...` — write/read roundtrip for `type`, `required`, `default` field names
- [ ] `go test -race ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)